### PR TITLE
Give /internal a door that opens

### DIFF
--- a/src/lib/gate-cookie.ts
+++ b/src/lib/gate-cookie.ts
@@ -12,7 +12,13 @@
 import { createHmac, timingSafeEqual } from "crypto";
 
 export const GATE_COOKIE_NAME = "anticipy_internal_gate";
-export const GATE_TTL_SECONDS = 15 * 60; // 15 minutes
+// 12 hours. It was 15 minutes, which is a sane number for a one-off demo
+// link and a miserable one for /internal, where people now work all day:
+// HQ would drop them mid-sentence four times an hour and the cookie is
+// httpOnly, so nothing in the page can even see it coming. This is a
+// passcode gate on internal docs, not an identity session — the thing it
+// protects against is a stranger with the URL, and 12 hours does that.
+export const GATE_TTL_SECONDS = 12 * 60 * 60; // 12 hours
 
 function getSecret(): string {
   // Reuse SUPABASE_SERVICE_ROLE_KEY for HMAC unless GATE_COOKIE_SECRET is set.

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -50,6 +50,86 @@ async function verifyGateCookie(
   return safeEqualHex(sig, expected);
 }
 
+// The unlock page. Served as the BODY of the 401 — the status stays 401 so
+// scrapers and search engines still get a refusal, and the body carries no
+// internal content at all, only a password box. That keeps B061's property
+// (nothing readable without the cookie) while giving a human a way in.
+//
+// This exists because there was no way in. src/app/internal/PasswordGate.tsx
+// is a real form, but it lives in the /internal LAYOUT — and this middleware
+// returns before Next renders any layout, so that form could never appear on
+// a deployed site. Every visitor, including the people who own the docs, got
+// a plain-text sentence naming a JSON endpoint they cannot type into.
+//
+// Warm palette only, matching PasswordGate: ink #0C0C0C, champagne #C8A97E.
+// No blue anywhere in this codebase, deliberately.
+const UNLOCK_PAGE = `<!doctype html>
+<html lang="en"><head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="robots" content="noindex,nofollow">
+<title>Anticipy — Internal</title>
+<style>
+  :root { color-scheme: dark; }
+  * { box-sizing: border-box; }
+  body { margin:0; min-height:100vh; display:flex; align-items:center;
+         justify-content:center; background:#0C0C0C; color:#F5F0EB;
+         font:16px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif; }
+  .box { width:100%; max-width:360px; padding:40px 24px; text-align:center; }
+  h1 { font:400 28px/1.2 Georgia,"Times New Roman",serif; color:#C8A97E;
+       letter-spacing:.06em; margin:0 0 8px; }
+  p.sub { color:#8A8A8A; font-size:14px; margin:0 0 32px; }
+  input { width:100%; padding:14px 16px; border-radius:12px;
+          border:1px solid #2A2A2A; background:#1E1E1E; color:#F5F0EB;
+          font-size:17px; text-align:center; letter-spacing:.08em; }
+  input:focus { outline:2px solid #C8A97E; outline-offset:2px; border-color:#C8A97E; }
+  button { width:100%; margin-top:12px; padding:14px 16px; border:0;
+           border-radius:999px; background:#C8A97E; color:#0C0C0C;
+           font-size:16px; font-weight:600; cursor:pointer; }
+  button:disabled { opacity:.55; cursor:default; }
+  button:focus-visible { outline:2px solid #F5F0EB; outline-offset:2px; }
+  .msg { min-height:20px; margin-top:16px; font-size:14px; color:#C96A5A; }
+  .hint { margin-top:28px; font-size:12px; color:#5A5A5A; }
+</style>
+</head><body>
+<div class="box">
+  <h1>ANTICIPY</h1>
+  <p class="sub">Internal — enter access code</p>
+  <form id="f" autocomplete="off">
+    <input id="c" type="password" inputmode="text" enterkeyhint="go"
+           aria-label="Access code" autofocus>
+    <button id="b" type="submit">Unlock</button>
+  </form>
+  <div class="msg" id="m" role="status" aria-live="polite"></div>
+  <p class="hint">This device stays unlocked for 12 hours.</p>
+</div>
+<script>
+(function () {
+  var f = document.getElementById("f"), c = document.getElementById("c"),
+      b = document.getElementById("b"), m = document.getElementById("m");
+  f.addEventListener("submit", function (ev) {
+    ev.preventDefault();
+    if (b.disabled) return;
+    b.disabled = true; m.textContent = "";
+    fetch("/api/internal-gate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ passcode: c.value.replace(/\\s+/g, "") })
+    }).then(function (r) {
+      if (r.ok) { location.reload(); return null; }
+      if (r.status === 429) { m.textContent = "Too many tries. Wait a minute."; }
+      else { m.textContent = "Wrong code."; }
+      b.disabled = false; c.select();
+      return null;
+    }).catch(function () {
+      m.textContent = "Network error. Try again.";
+      b.disabled = false;
+    });
+  });
+})();
+</script>
+</body></html>`;
+
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
@@ -70,11 +150,26 @@ export async function middleware(request: NextRequest) {
     const cookie = request.cookies.get(GATE_COOKIE_NAME)?.value;
     const ok = await verifyGateCookie(cookie);
     if (!ok) {
-      // Return a minimal 401 page rather than redirecting so search
-      // engines and curl-based scrapers don't get a 200 with content.
+      // Still a 401 either way, so search engines and curl-based scrapers
+      // never get a 200 with content. What changes is the BODY: a browser
+      // navigation gets the unlock form, everything else gets the sentence.
+      //
+      // Content negotiation rather than a redirect: a redirect to a /gate
+      // page would be a 200 somewhere, and the whole point of B061 was that
+      // no URL under here answers 200 without the cookie.
+      const wantsHtml = (request.headers.get("accept") || "").includes("text/html");
+      const headers: Record<string, string> = {
+        "cache-control": "no-store",
+        "x-robots-tag": "noindex, nofollow",
+        "content-type": wantsHtml
+          ? "text/html; charset=utf-8"
+          : "text/plain; charset=utf-8",
+      };
       return new NextResponse(
-        "Internal area. Pass the gate at /api/internal-gate first.",
-        { status: 401, headers: { "content-type": "text/plain" } }
+        wantsHtml
+          ? UNLOCK_PAGE
+          : "Internal area. Pass the gate at /api/internal-gate first.",
+        { status: 401, headers }
       );
     }
   }


### PR DESCRIPTION
`/internal` and everything under it has been **unreachable** on the deployed site — not gated, unreachable. That includes the hardware hub (BOM, schematic, assembly, manufacturing, packaging) and, as of #8, HQ.

Two independent causes. Both confirmed against production before this change.

### 1. There was no form

`src/app/internal/PasswordGate.tsx` is a real, working passcode form. It is rendered by `src/app/internal/layout.tsx` — and `src/middleware.ts` returns 401 **before Next renders any layout**. So it could never appear on a deployed site.

```
$ curl -H 'Accept: text/html' https://www.anticipy.ai/internal
401  content-type: text/plain
Internal area. Pass the gate at /api/internal-gate first.
```

A sentence naming a JSON endpoint you cannot type into.

### 2. There was no passcode

```
$ vercel env ls production | grep GATE_PASSCODE_INTERNAL
(nothing)
```

`expectedPasscode()` fail-secures to `null` when that env is missing in production, so **every** POST to `/api/internal-gate` returned 401 "Wrong code" — including the right code. The gate cookie could not be minted by anyone, by any route, ever.

Now set in Production and Preview.

## What changes — and what deliberately does not

The status stays **401 on every path**, and the body still carries **zero internal content**. B061 fixed a real leak (hardware spec, block diagrams, BOM and pinouts rendering server-side behind a JS-only gate) and none of that is reopened.

What changes is only the *body* of the refusal, chosen by `Accept`:

| Request | Status | Body |
|---|---|---|
| browser navigation (`text/html`) | 401 | a password box, and nothing else |
| curl, scraper, fetch, bot | 401 | the same plain sentence as before |

Content negotiation rather than a redirect to a `/gate` page — a redirect means some URL answers 200 without the cookie, and that is exactly the property B061 bought.

Also added to the refusal: `cache-control: no-store` and `x-robots-tag: noindex, nofollow`.

## Cookie lifetime: 15 minutes → 12 hours

Fine for a one-off demo link. Miserable for `/internal`, where HQ now lives and people work all day — it would drop them mid-sentence four times an hour, and the cookie is `httpOnly`, so nothing in the page can see it coming.

This is a passcode gate on internal docs, not an identity session. What it defends against is a stranger with the URL, and 12 hours does that.

## Verified

- both files parse (esbuild)
- unlock page rendered headless at 1000px and at a **true** 390px (iframe of exact width — Chrome clamps `--window-size` below ~500 and silently lies)
- every colour checked against the no-blue rule: `#0C0C0C #1E1E1E #2A2A2A #5A5A5A #8A8A8A #C8A97E #C96A5A #F5F0EB` — all warm, none blue
- template literal contains no `${` and no stray backtick

🤖 Generated with [Claude Code](https://claude.com/claude-code)