### PR TITLE
Forward the /internal routes the rebuilt HQ calls

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -101,10 +101,18 @@ const nextConfig = {
       { source: "/internal/events", destination: `${FELLOWSHIP_ORIGIN}/internal/events` },
       { source: "/internal/events/delete", destination: `${FELLOWSHIP_ORIGIN}/internal/events/delete` },
       { source: "/internal/tracks", destination: `${FELLOWSHIP_ORIGIN}/internal/tracks` },
-      { source: "/internal/router", destination: `${FELLOWSHIP_ORIGIN}/internal/router` },
-      { source: "/internal/assistant", destination: `${FELLOWSHIP_ORIGIN}/internal/assistant` },
-      { source: "/internal/research", destination: `${FELLOWSHIP_ORIGIN}/internal/research` },
-      { source: "/internal/research/status", destination: `${FELLOWSHIP_ORIGIN}/internal/research/status` },
+      // Signing in as yourself, and the seven routes HQ calls once you are.
+      // These were missing, so /internal/me 404'd at the edge and the page
+      // could never learn who you were — it reached the person picker and
+      // then stopped dead. Enumerated, never globbed: /internal/docs/* is a
+      // real Next route and a catch-all would swallow the whole hardware hub.
+      { source: "/internal/me", destination: `${FELLOWSHIP_ORIGIN}/internal/me` },
+      { source: "/internal/session", destination: `${FELLOWSHIP_ORIGIN}/internal/session` },
+      { source: "/internal/session/end", destination: `${FELLOWSHIP_ORIGIN}/internal/session/end` },
+      { source: "/internal/people/code", destination: `${FELLOWSHIP_ORIGIN}/internal/people/code` },
+      { source: "/internal/comments", destination: `${FELLOWSHIP_ORIGIN}/internal/comments` },
+      { source: "/internal/notifs/read", destination: `${FELLOWSHIP_ORIGIN}/internal/notifs/read` },
+      { source: "/internal/settings", destination: `${FELLOWSHIP_ORIGIN}/internal/settings` },
       { source: "/internal/fellows", destination: `${FELLOWSHIP_ORIGIN}/internal/fellows` },
       { source: "/internal/fellows/remove", destination: `${FELLOWSHIP_ORIGIN}/internal/fellows/remove` },
     ];


### PR DESCRIPTION
HQ has been rebuilt from the Claude Design prototype and the AI surface removed — no assistant, no task router, no research lane, no dictation, no read-aloud. The new page is already live on the backend; this is the edge catching up.

## The bug this fixes

You could type the team key, reach **Who's typing?**, pick your name — and get `HTTP 404`.

`GET /internal/me` never left Vercel. It is the call that tells the page who you are, and it had no rewrite, so login completed and then stopped dead.

## Added — seven routes

| Route | What it does |
|---|---|
| `/internal/me` | who am I + the team rules, called once on boot |
| `/internal/session` | sign in with your own code |
| `/internal/session/end` | sign out |
| `/internal/people/code` | mint a personal code (shown once, never again) |
| `/internal/comments` | task comments |
| `/internal/notifs/read` | mark notifications read |
| `/internal/settings` | team name and the two permission rules |

All seven already exist on the backend and answer correctly at the Railway origin — verified by probing each one directly. Only the rewrite was missing.

## Removed — four routes

`/internal/assistant` · `/internal/router` · `/internal/research` · `/internal/research/status`

Nothing calls them any more. The handlers still exist on the backend, but there is no longer a door to them from anticipy.ai.

## Still enumerated, never globbed

`/internal/docs/*` is a real Next route. A `/internal/:path*` catch-all would swallow the entire hardware hub — BOM, schematic, assembly, manufacturing, packaging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)