### PR TITLE
Forward /internal/clerk/exchange

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -113,6 +113,9 @@ const nextConfig = {
       { source: "/internal/comments", destination: `${FELLOWSHIP_ORIGIN}/internal/comments` },
       { source: "/internal/notifs/read", destination: `${FELLOWSHIP_ORIGIN}/internal/notifs/read` },
       { source: "/internal/settings", destination: `${FELLOWSHIP_ORIGIN}/internal/settings` },
+      // Clerk sign-in: the page trades a verified Clerk token for an ordinary
+      // HQ session at this one route; nothing else in HQ knows Clerk exists.
+      { source: "/internal/clerk/exchange", destination: `${FELLOWSHIP_ORIGIN}/internal/clerk/exchange` },
       { source: "/internal/fellows", destination: `${FELLOWSHIP_ORIGIN}/internal/fellows` },
       { source: "/internal/fellows/remove", destination: `${FELLOWSHIP_ORIGIN}/internal/fellows/remove` },
     ];


### PR DESCRIPTION
One rewrite: the route where HQ trades a verified Clerk sign-in for its ordinary session token. Everything else about Clerk lives on the backend and in the page — the edge only needs this door.

Enumerated, never globbed — /internal/docs/* is a real Next route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)